### PR TITLE
Several improvements

### DIFF
--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.h
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.h
@@ -26,6 +26,11 @@
 - (void)setSGProgressPercentage:(float)percentage;
 - (void)setSGProgressPercentage:(float)percentage andTitle:(NSString *)title;
 - (void)setSGProgressPercentage:(float)percentage andTintColor:(UIColor *)tintColor;
+
+- (void)setSGProgressPercentage:(float)percentage duration:(float)duration;
+- (void)setSGProgressPercentage:(float)percentage duration:(float)duration andTitle:(NSString *)title;
+- (void)setSGProgressPercentage:(float)percentage duration:(float)duration andTintColor:(UIColor *)tintColor;
+
 - (void)setSGProgressMaskWithPercentage:(float)percentage;
 - (void)setSGProgressMaskWithPercentage:(float)percentage andTitle:(NSString *)title;
 

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.h
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.h
@@ -30,6 +30,7 @@
 - (void)setSGProgressPercentage:(float)percentage duration:(float)duration;
 - (void)setSGProgressPercentage:(float)percentage duration:(float)duration andTitle:(NSString *)title;
 - (void)setSGProgressPercentage:(float)percentage duration:(float)duration andTintColor:(UIColor *)tintColor;
+- (void)setSGProgressPercentage:(float)percentage duration:(float)duration title:(NSString *)title andTintColor:(UIColor *)tintColor;
 
 - (void)setSGProgressMaskWithPercentage:(float)percentage;
 - (void)setSGProgressMaskWithPercentage:(float)percentage andTitle:(NSString *)title;

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -28,14 +28,16 @@ CGFloat const SGProgressBarHeight = 2.5;
 		}
 	}
 
-	if (!_progressView)
-	{
-		CGRect slice, remainder;
-		CGRectDivide(self.navigationBar.bounds, &slice, &remainder, SGProgressBarHeight, CGRectMaxYEdge);
-		_progressView = [[SGProgressView alloc] initWithFrame:slice];
-		_progressView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
-		[self.navigationBar addSubview:_progressView];
-	}
+	return _progressView;
+}
+
+- (SGProgressView *)newProgressView
+{
+	CGRect slice, remainder;
+	CGRectDivide(self.navigationBar.bounds, &slice, &remainder, SGProgressBarHeight, CGRectMaxYEdge);
+	SGProgressView *_progressView = [[SGProgressView alloc] initWithFrame:slice];
+	_progressView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
+	[self.navigationBar addSubview:_progressView];
 
 	return _progressView;
 }
@@ -199,7 +201,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 
 - (void)showSGProgressWithDuration:(float)duration
 {
-	SGProgressView *progressView = [self progressView];
+	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
 
 	[UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionCurveEaseIn animations:^{
 		progressView.progress = 1;
@@ -220,7 +222,8 @@ CGFloat const SGProgressBarHeight = 2.5;
 
 - (void)showSGProgressWithDuration:(float)duration andTintColor:(UIColor *)tintColor
 {
-	[[self progressView] setTintColor:tintColor];
+	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
+	[progressView setTintColor:tintColor];
 	[self showSGProgressWithDuration:duration];
 }
 
@@ -245,6 +248,11 @@ CGFloat const SGProgressBarHeight = 2.5;
 - (void)finishSGProgress
 {
 	SGProgressView *progressView = [self progressView];
+	if (!progressView)
+	{
+		return;
+	}
+
 	progressView.progress = 0.99;	// Trigger animation with progress change
 
 	__weak typeof(self)weakSelf = self;
@@ -261,6 +269,11 @@ CGFloat const SGProgressBarHeight = 2.5;
 - (void)cancelSGProgress
 {
 	SGProgressView *progressView = [self progressView];
+	if (!progressView)
+	{
+		return;
+	}
+
 	[UIView animateWithDuration:0.5 animations:^{
 		progressView.alpha = 0;
 	} completion:^(BOOL finished) {
@@ -272,7 +285,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 
 - (void)setSGProgressPercentage:(float)percentage
 {
-	SGProgressView *progressView = [self progressView];
+	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
 
 	[UIView animateWithDuration:0.1 delay:0 options:UIViewAnimationOptionCurveLinear animations:^{
 		progressView.progress = percentage / 100.f;
@@ -299,7 +312,8 @@ CGFloat const SGProgressBarHeight = 2.5;
 
 - (void)setSGProgressPercentage:(float)percentage andTintColor:(UIColor *)tintColor
 {
-	[[self progressView] setTintColor:tintColor];
+	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
+	[progressView setTintColor:tintColor];
 	[self setSGProgressPercentage:percentage];
 }
 

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -251,7 +251,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 	[self resetTitle];
 	progressView.progress = 0.99;	// Trigger animation with progress change
 
-	[UIView animateWithDuration:0.5 animations:^{
+	[UIView animateWithDuration:0.5 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
 		progressView.progress = 1;
 	} completion:^(BOOL finished) {
 		[self cancelSGProgress];
@@ -280,7 +280,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 {
 	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
 
-	[UIView animateWithDuration:0.1 delay:0.5 options:UIViewAnimationOptionCurveLinear animations:^{
+	[UIView animateWithDuration:0.1 delay:0.5 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
 		progressView.progress = percentage / 100.f;
 
 	} completion:^(BOOL finished) {
@@ -308,7 +308,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 {
 	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
 
-	[UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionCurveLinear animations:^{
+	[UIView animateWithDuration:duration delay:0 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
 		progressView.progress = percentage / 100.f;
 
 	} completion:^(BOOL finished) {

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -167,10 +167,10 @@ CGFloat const SGProgressBarHeight = 2.5;
 		[[NSUserDefaults standardUserDefaults] setObject:oldTitle forKey:kSGProgressOldTitle];
 		[[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithBool:YES] forKey:kSGProgressTitleChanged];
 		[[NSUserDefaults standardUserDefaults] synchronize];
-
-		//add animation
-		self.visibleViewController.navigationItem.title = title;
 	}
+	
+	//add animation, allows multiple title changes
+	self.visibleViewController.navigationItem.title = title;
 }
 
 #pragma mark - UIViewController

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -249,7 +249,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 
 	progressView.progress = 0.99;	// Trigger animation with progress change
 
-	[UIView animateWithDuration:0.2 animations:^{
+	[UIView animateWithDuration:0.5 animations:^{
 		progressView.progress = 1;
 	} completion:^(BOOL finished) {
 		[self cancelSGProgress];

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -209,13 +209,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 	} completion:^(BOOL finished) {
         if (finished)
 		{
-			[UIView animateWithDuration:0.5 animations:^{
-				progressView.alpha = 0;
-			} completion:^(BOOL finished) {
-				[progressView removeFromSuperview];
-				[self removeSGMask];
-				[self resetTitle];
-			}];
+			[self cancelSGProgress];
 		}
 	}];
 }
@@ -255,15 +249,11 @@ CGFloat const SGProgressBarHeight = 2.5;
 
 	progressView.progress = 0.99;	// Trigger animation with progress change
 
-	__weak typeof(self)weakSelf = self;
-	[UIView animateWithDuration:0.2
-						  delay:0
-						options:UIViewAnimationOptionBeginFromCurrentState
-					 animations:^{
-						 progressView.progress = 1;
-					 } completion:^(BOOL finished) {
-						 [weakSelf cancelSGProgress];
-					 }];
+	[UIView animateWithDuration:0.2 animations:^{
+		progressView.progress = 1;
+	} completion:^(BOOL finished) {
+		[self cancelSGProgress];
+	}];
 }
 
 - (void)cancelSGProgress
@@ -293,13 +283,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 	} completion:^(BOOL finished) {
 		if (percentage >= 100)
 		{
-			[UIView animateWithDuration:0.5 animations:^{
-				progressView.alpha = 0;
-			} completion:^(BOOL finished) {
-				[progressView removeFromSuperview];
-				[self removeSGMask];
-				[self resetTitle];
-			}];
+			[self cancelSGProgress];
 		}
 	}];
 }

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -37,6 +37,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 	CGRectDivide(self.navigationBar.bounds, &slice, &remainder, SGProgressBarHeight, CGRectMaxYEdge);
 	SGProgressView *_progressView = [[SGProgressView alloc] initWithFrame:slice];
 	_progressView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
+	_progressView.tintColor = [[[UIApplication sharedApplication] delegate] window].tintColor;
 	[self.navigationBar addSubview:_progressView];
 
 	return _progressView;

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -301,6 +301,34 @@ CGFloat const SGProgressBarHeight = 2.5;
 	[self setSGProgressPercentage:percentage];
 }
 
+- (void)setSGProgressPercentage:(float)percentage duration:(float)duration
+{
+	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
+
+	[UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionCurveLinear animations:^{
+		progressView.progress = percentage / 100.f;
+
+	} completion:^(BOOL finished) {
+		if (percentage >= 100)
+		{
+			[self cancelSGProgress];
+		}
+	}];
+}
+
+- (void)setSGProgressPercentage:(float)percentage duration:(float)duration andTitle:(NSString *)title
+{
+	[self changeSGProgressWithTitle:title];
+	[self setSGProgressPercentage:percentage duration:(float)duration];
+}
+
+- (void)setSGProgressPercentage:(float)percentage duration:(float)duration andTintColor:(UIColor *)tintColor
+{
+	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
+	[progressView setTintColor:tintColor];
+	[self setSGProgressPercentage:percentage duration:(float)duration];
+}
+
 - (void)setSGProgressMaskWithPercentage:(float)percentage
 {
 	[self setSGProgressPercentage:percentage];

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -203,14 +203,18 @@ CGFloat const SGProgressBarHeight = 2.5;
 
 	[UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionCurveEaseIn animations:^{
 		progressView.progress = 1;
+
 	} completion:^(BOOL finished) {
-		[UIView animateWithDuration:0.5 animations:^{
-			progressView.alpha = 0;
-		} completion:^(BOOL finished) {
-			[progressView removeFromSuperview];
-			[self removeSGMask];
-			[self resetTitle];
-		}];
+        if (finished)
+		{
+			[UIView animateWithDuration:0.5 animations:^{
+				progressView.alpha = 0;
+			} completion:^(BOOL finished) {
+				[progressView removeFromSuperview];
+				[self removeSGMask];
+				[self resetTitle];
+			}];
+		}
 	}];
 }
 
@@ -241,9 +245,17 @@ CGFloat const SGProgressBarHeight = 2.5;
 - (void)finishSGProgress
 {
 	SGProgressView *progressView = [self progressView];
-	[UIView animateWithDuration:0.1 animations:^{
-		progressView.progress = 1;
-	}];
+	progressView.progress = 0.99;	// Trigger animation with progress change
+
+	__weak typeof(self)weakSelf = self;
+	[UIView animateWithDuration:0.2
+						  delay:0
+						options:UIViewAnimationOptionBeginFromCurrentState
+					 animations:^{
+						 progressView.progress = 1;
+					 } completion:^(BOOL finished) {
+						 [weakSelf cancelSGProgress];
+					 }];
 }
 
 - (void)cancelSGProgress

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -330,6 +330,12 @@ CGFloat const SGProgressBarHeight = 2.5;
 	[self setSGProgressPercentage:percentage duration:(float)duration];
 }
 
+- (void)setSGProgressPercentage:(float)percentage duration:(float)duration title:(NSString *)title andTintColor:(UIColor *)tintColor
+{
+	[self changeSGProgressWithTitle:title];
+	[self setSGProgressPercentage:percentage duration:(float)duration andTintColor:tintColor];
+}
+
 - (void)setSGProgressMaskWithPercentage:(float)percentage
 {
 	[self setSGProgressPercentage:percentage];

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -251,7 +251,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 	[self resetTitle];
 	progressView.progress = 0.99;	// Trigger animation with progress change
 
-	[UIView animateWithDuration:0.5 delay:0  options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
+	[UIView animateWithDuration:0.2 delay:0  options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
 		progressView.progress = 1;
 	} completion:^(BOOL finished) {
 		[self cancelSGProgress];
@@ -280,7 +280,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 {
 	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
 
-	[UIView animateWithDuration:0.1 delay:0.5 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
+	[UIView animateWithDuration:0.1 delay:0 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
 		progressView.progress = percentage / 100.f;
 
 	} completion:^(BOOL finished) {
@@ -308,7 +308,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 {
 	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
 
-	[UIView animateWithDuration:duration delay:0.5 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
+	[UIView animateWithDuration:duration delay:0.1 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
 		progressView.progress = percentage / 100.f;
 
 	} completion:^(BOOL finished) {

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -251,7 +251,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 	[self resetTitle];
 	progressView.progress = 0.99;	// Trigger animation with progress change
 
-	[UIView animateWithDuration:0.5 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
+	[UIView animateWithDuration:0.5 delay:0  options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
 		progressView.progress = 1;
 	} completion:^(BOOL finished) {
 		[self cancelSGProgress];
@@ -308,7 +308,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 {
 	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
 
-	[UIView animateWithDuration:duration delay:0 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
+	[UIView animateWithDuration:duration delay:0.5 options:( UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear ) animations:^{
 		progressView.progress = percentage / 100.f;
 
 	} completion:^(BOOL finished) {

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -37,7 +37,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 	CGRectDivide(self.navigationBar.bounds, &slice, &remainder, SGProgressBarHeight, CGRectMaxYEdge);
 	SGProgressView *_progressView = [[SGProgressView alloc] initWithFrame:slice];
 	_progressView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
-	_progressView.tintColor = [[[UIApplication sharedApplication] delegate] window].tintColor;
+	_progressView.tintColor = self.navigationBar.tintColor;
 	[self.navigationBar addSubview:_progressView];
 
 	return _progressView;

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -247,7 +247,8 @@ CGFloat const SGProgressBarHeight = 2.5;
 	{
 		return;
 	}
-
+	
+	[self resetTitle];
 	progressView.progress = 0.99;	// Trigger animation with progress change
 
 	[UIView animateWithDuration:0.5 animations:^{
@@ -264,13 +265,14 @@ CGFloat const SGProgressBarHeight = 2.5;
 	{
 		return;
 	}
+	
+	[self resetTitle];
 
 	[UIView animateWithDuration:0.5 animations:^{
 		progressView.alpha = 0;
 	} completion:^(BOOL finished) {
 		[progressView removeFromSuperview];
 		[self removeSGMask];
-		[self resetTitle];
 	}];
 }
 

--- a/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
+++ b/SGNavigationProgress/UINavigationController+SGProgress/UINavigationController+SGProgress.m
@@ -280,7 +280,7 @@ CGFloat const SGProgressBarHeight = 2.5;
 {
 	SGProgressView *progressView = [self progressView] ?: [self newProgressView];
 
-	[UIView animateWithDuration:0.1 delay:0 options:UIViewAnimationOptionCurveLinear animations:^{
+	[UIView animateWithDuration:0.1 delay:0.5 options:UIViewAnimationOptionCurveLinear animations:^{
 		progressView.progress = percentage / 100.f;
 
 	} completion:^(BOOL finished) {

--- a/SGNavigationProgress/ViewController.m
+++ b/SGNavigationProgress/ViewController.m
@@ -38,7 +38,8 @@
 
 - (IBAction)finishPressed:(id)sender
 {
-	[self.navigationController finishSGProgress];
+	[self.currentProgress cancel];
+	[self.navigationController performSelector:@selector(finishSGProgress) withObject:nil afterDelay:0.1];
 }
 
 - (IBAction)cancelPressed:(id)sender


### PR DESCRIPTION
Built upon sgryschuk/SGNavigationProgress#11
- Fixed bug with changing the title back when presenting a view controller directly after loading is completed.
- Allows multiple loading title changes to indicate several loading stages. (e.g. Authenticating, Retrieving data)
- Added methods for setting a percentage animated with a specific duration. Could be used to load from the network. For example at the start of a request you can animate to 90 % in 3 seconds and when the data is actually loaded you can finish with the `finishSGProgress`
- Sets the `tintColor` to the same value as the `navigationBar.tintColor`.
- Animates more smoothly by using `UIViewAnimationOptionBeginFromCurrentState` 
